### PR TITLE
feat(elements): add props 'disableTooltip' and 'disableCopy' to holo-identicon

### DIFF
--- a/packages/elements/custom-elements.json
+++ b/packages/elements/custom-elements.json
@@ -474,7 +474,7 @@
             },
             {
               "kind": "field",
-              "name": "copyOnClick",
+              "name": "disableCopy",
               "type": {
                 "text": "boolean"
               },
@@ -483,7 +483,7 @@
             },
             {
               "kind": "field",
-              "name": "showOnHover",
+              "name": "disableTooltip",
               "type": {
                 "text": "boolean"
               },

--- a/packages/elements/custom-elements.json
+++ b/packages/elements/custom-elements.json
@@ -474,6 +474,24 @@
             },
             {
               "kind": "field",
+              "name": "copyOnClick",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Copy AgentPubKey to clipboard on click"
+            },
+            {
+              "kind": "field",
+              "name": "showOnHover",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Show tooltip on hover with truncated AgentPubKey"
+            },
+            {
+              "kind": "field",
               "name": "_canvas",
               "type": {
                 "text": "HTMLCanvasElement"

--- a/packages/elements/demo/index.html
+++ b/packages/elements/demo/index.html
@@ -13,6 +13,11 @@
     <holo-identicon
       hash="uhCEkBsnnW9JSVhGQx4AE2m0lSlWLrioEHP-7Uj4ZnbI0W-M"
     ></holo-identicon>
+    <holo-identicon
+      hash="uhCEkBsnnW9JXVhGQx4AE2m0lSlWLrioEHP-7Uj4ZnbI0W-M"
+      showOnHover
+      copyOnClick
+    ></holo-identicon>
     <form>
       <select-avatar required></select-avatar>
       <input type="submit" />

--- a/packages/elements/demo/index.html
+++ b/packages/elements/demo/index.html
@@ -15,8 +15,8 @@
     ></holo-identicon>
     <holo-identicon
       hash="uhCEkBsnnW9JXVhGQx4AE2m0lSlWLrioEHP-7Uj4ZnbI0W-M"
-      showOnHover
-      copyOnClick
+      disableCopy
+      disableTooltip
     ></holo-identicon>
     <form>
       <select-avatar required></select-avatar>

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain-open-dev/elements",
-  "version": "0.4.0",
+  "version": "0.3.10",
   "description": "Common utilities and elements to build Holochain web applications",
   "author": "guillem.cordoba@gmail.com",
   "main": "dist/index.js",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain-open-dev/elements",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Common utilities and elements to build Holochain web applications",
   "author": "guillem.cordoba@gmail.com",
   "main": "dist/index.js",

--- a/packages/elements/src/elements/holo-identicon.ts
+++ b/packages/elements/src/elements/holo-identicon.ts
@@ -27,6 +27,18 @@ export class HoloIdenticon extends LitElement {
   @property({ type: String })
   shape: "square" | "circle" = "circle";
 
+  /**
+   * Copy AgentPubKey to clipboard on click
+   */
+  @property({ type: Boolean })
+  copyOnClick = false;
+
+  /**
+   * Show tooltip on hover with truncated AgentPubKey
+   */
+  @property({ type: Boolean })
+  showOnHover = false;
+
   @query("#canvas")
   private _canvas!: HTMLCanvasElement;
 
@@ -90,10 +102,17 @@ export class HoloIdenticon extends LitElement {
   }
 
   render() {
-    return html`<div
-      @click=${() => this.copyHash()}
-      style="cursor: pointer; flex-grow: 0"
-    >
+    const content = html`
+      <div
+        @click=${() => {
+          if (this.copyOnClick) this.copyHash();
+        }}
+        style="cursor: pointer; flex-grow: 0"
+      >
+          ${this.renderCanvas()}
+      </div>`;
+
+    return this.showOnHover ? html`
       <sl-tooltip
         id="tooltip"
         placement="top"
@@ -103,9 +122,9 @@ export class HoloIdenticon extends LitElement {
         .trigger=${this.justCopiedHash ? "manual" : "hover focus"}
         hoist
       >
-        ${this.renderCanvas()}
-      </sl-tooltip>
-    </div>`;
+        ${content}
+      </sl-tooltip>` 
+      : content;
   }
 
   static get styles() {

--- a/packages/elements/src/elements/holo-identicon.ts
+++ b/packages/elements/src/elements/holo-identicon.ts
@@ -31,13 +31,13 @@ export class HoloIdenticon extends LitElement {
    * Copy AgentPubKey to clipboard on click
    */
   @property({ type: Boolean })
-  copyOnClick = false;
+  disableCopy = false;
 
   /**
    * Show tooltip on hover with truncated AgentPubKey
    */
   @property({ type: Boolean })
-  showOnHover = false;
+  disableTooltip = false;
 
   @query("#canvas")
   private _canvas!: HTMLCanvasElement;
@@ -105,14 +105,15 @@ export class HoloIdenticon extends LitElement {
     const content = html`
       <div
         @click=${() => {
-          if (this.copyOnClick) this.copyHash();
+          if (!this.disableCopy) this.copyHash();
         }}
         style="cursor: pointer; flex-grow: 0"
       >
           ${this.renderCanvas()}
       </div>`;
 
-    return this.showOnHover ? html`
+    return this.disableTooltip ? content :
+     html`
       <sl-tooltip
         id="tooltip"
         placement="top"
@@ -123,8 +124,7 @@ export class HoloIdenticon extends LitElement {
         hoist
       >
         ${content}
-      </sl-tooltip>` 
-      : content;
+      </sl-tooltip>`;
   }
 
   static get styles() {


### PR DESCRIPTION
- add props to disableTooltip & disbleCopy to `<holo-identicon>`
- both features are still enabled by default
- added example to demo
