### PR TITLE
Build/bump holochain js deps on 0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,9 +2690,9 @@
 			"link": true
 		},
 		"node_modules/@holochain/client": {
-			"version": "0.17.0-dev.12",
-			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.17.0-dev.12.tgz",
-			"integrity": "sha512-aEOkD4wtFeHAv5AiEkBfsiGeAujCyQf1yfvmtcdERnv73zgZhxCiZ0ZrEi46kdJhRHMXX/1Qkqo6VY8afrepfQ==",
+			"version": "0.18.0-dev.10",
+			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.18.0-dev.10.tgz",
+			"integrity": "sha512-70LkUb//tHb+g4oPJQFqyi7axJlrQyXy86W9WFG/lAoVFo4NBBFvVOee8oOg+JxvgxJnevlLPsKePzU3I2tnNw==",
 			"dependencies": {
 				"@bitgo/blake2b": "^3.2.4",
 				"@holochain/serialization": "^0.1.0-beta-rc.3",
@@ -8887,32 +8887,13 @@
 			"version": "0.400.0-dev.0",
 			"license": "ISC",
 			"dependencies": {
-				"@holochain/client": "^0.18.0-dev.0"
+				"@holochain/client": "^0.18.0-dev.10"
 			},
 			"devDependencies": {
 				"@types/libsodium-wrappers": "^0.7.10",
 				"@types/node": "^16.11.10",
 				"@types/ws": "^8.2.0",
 				"typescript": "^5.4.0"
-			}
-		},
-		"packages/core-types/node_modules/@holochain/client": {
-			"version": "0.18.0-dev.0",
-			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.18.0-dev.0.tgz",
-			"integrity": "sha512-xQ4J5rG+t1aJrtzZK8BsJYLsYHgG4zoUvsmoUuiKZcvVRlxPldX+p6rWYWz0JuDxlTE5hjmJmBTPWXd+WVHGNw==",
-			"dependencies": {
-				"@bitgo/blake2b": "^3.2.4",
-				"@holochain/serialization": "^0.1.0-beta-rc.3",
-				"@msgpack/msgpack": "^2.8.0",
-				"emittery": "^1.0.1",
-				"isomorphic-ws": "^5.0.0",
-				"js-base64": "^3.7.5",
-				"libsodium-wrappers": "^0.7.13",
-				"lodash-es": "^4.17.21",
-				"ws": "^8.14.2"
-			},
-			"engines": {
-				"node": ">=18.0.0 || >=20.0.0"
 			}
 		},
 		"packages/core-types/node_modules/@types/node": {
@@ -8926,7 +8907,7 @@
 			"version": "0.400.0-dev.0",
 			"dependencies": {
 				"@holo-host/identicon": "^0.1.0",
-				"@holochain/client": "^0.18.0-dev.0",
+				"@holochain/client": "^0.18.0-dev.10",
 				"@lit/localize": "^0.12.0",
 				"@mdi/js": "^7.1.96",
 				"@shoelace-style/shoelace": "^2.11.0",
@@ -8944,25 +8925,6 @@
 				"vite-plugin-checker": "^0.5.5"
 			}
 		},
-		"packages/elements/node_modules/@holochain/client": {
-			"version": "0.18.0-dev.0",
-			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.18.0-dev.0.tgz",
-			"integrity": "sha512-xQ4J5rG+t1aJrtzZK8BsJYLsYHgG4zoUvsmoUuiKZcvVRlxPldX+p6rWYWz0JuDxlTE5hjmJmBTPWXd+WVHGNw==",
-			"dependencies": {
-				"@bitgo/blake2b": "^3.2.4",
-				"@holochain/serialization": "^0.1.0-beta-rc.3",
-				"@msgpack/msgpack": "^2.8.0",
-				"emittery": "^1.0.1",
-				"isomorphic-ws": "^5.0.0",
-				"js-base64": "^3.7.5",
-				"libsodium-wrappers": "^0.7.13",
-				"lodash-es": "^4.17.21",
-				"ws": "^8.14.2"
-			},
-			"engines": {
-				"node": ">=18.0.0 || >=20.0.0"
-			}
-		},
 		"packages/elements/node_modules/typescript": {
 			"version": "4.9.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -8978,10 +8940,10 @@
 		},
 		"packages/signals": {
 			"name": "@holochain-open-dev/signals",
-			"version": "0.400.0-dev.0",
+			"version": "0.400.0-dev.1",
 			"dependencies": {
-				"@holochain-open-dev/utils": "^0.400.0-dev.0",
-				"@holochain/client": "^0.18.0-dev.0",
+				"@holochain-open-dev/utils": "^0.400.0-dev.1",
+				"@holochain/client": "^0.18.0-dev.10",
 				"@shoelace-style/shoelace": "^2.11.2",
 				"async-signals": "^0.1.7",
 				"lit-signal-watcher": "^0.1.0",
@@ -9345,25 +9307,6 @@
 			],
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"packages/signals/node_modules/@holochain/client": {
-			"version": "0.18.0-dev.0",
-			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.18.0-dev.0.tgz",
-			"integrity": "sha512-xQ4J5rG+t1aJrtzZK8BsJYLsYHgG4zoUvsmoUuiKZcvVRlxPldX+p6rWYWz0JuDxlTE5hjmJmBTPWXd+WVHGNw==",
-			"dependencies": {
-				"@bitgo/blake2b": "^3.2.4",
-				"@holochain/serialization": "^0.1.0-beta-rc.3",
-				"@msgpack/msgpack": "^2.8.0",
-				"emittery": "^1.0.1",
-				"isomorphic-ws": "^5.0.0",
-				"js-base64": "^3.7.5",
-				"libsodium-wrappers": "^0.7.13",
-				"lodash-es": "^4.17.21",
-				"ws": "^8.14.2"
-			},
-			"engines": {
-				"node": ">=18.0.0 || >=20.0.0"
 			}
 		},
 		"packages/signals/node_modules/@vitest/expect": {
@@ -9804,11 +9747,11 @@
 		},
 		"packages/stores": {
 			"name": "@holochain-open-dev/stores",
-			"version": "0.300.0-dev.4",
+			"version": "0.300.0-dev.5",
 			"dependencies": {
 				"@alenaksu/json-viewer": "^2.0.1",
-				"@holochain-open-dev/utils": "^0.300.0-dev.0",
-				"@holochain/client": "^0.17.0-dev.12",
+				"@holochain-open-dev/utils": "^0.400.0-dev.1",
+				"@holochain/client": "^0.18.0-dev.10",
 				"@scoped-elements/cytoscape": "^0.2.0",
 				"@shoelace-style/shoelace": "^2.11.2",
 				"lit": "^3.0.2",
@@ -9826,17 +9769,44 @@
 				"vitest": "^0.28.5"
 			}
 		},
-		"packages/stores/node_modules/@holochain-open-dev/utils": {
-			"version": "0.300.0-dev.2",
-			"resolved": "https://registry.npmjs.org/@holochain-open-dev/utils/-/utils-0.300.0-dev.2.tgz",
-			"integrity": "sha512-V4kwnfnVrxg35tiRebijDl8SCTJ7f+icIK7Apbwy5DwOOfdNH9/MinvkHP9ef26i6QooBuxlvwaLh0PvKgwegQ==",
+		"packages/stores/node_modules/@holochain-open-dev/utils/node_modules/@holochain/client": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.17.1.tgz",
+			"integrity": "sha512-Jvh6DN+OdktV3KQH+tioRzvPT+LWJFBp1klMFG9vaccphIVvJN1LepJfRB8OyxW5iGAZ/TFCTwF19XSJuM1fQQ==",
+			"extraneous": true,
 			"dependencies": {
-				"@holochain/client": "^0.17.0-dev.12",
+				"@bitgo/blake2b": "^3.2.4",
+				"@holochain/serialization": "^0.1.0-beta-rc.3",
 				"@msgpack/msgpack": "^2.8.0",
-				"blakejs": "^1.2.1",
 				"emittery": "^1.0.1",
+				"isomorphic-ws": "^5.0.0",
+				"js-base64": "^3.7.5",
+				"libsodium-wrappers": "^0.7.13",
 				"lodash-es": "^4.17.21",
-				"sort-keys": "^5.0.0"
+				"ws": "^8.14.2"
+			},
+			"devDependencies": {
+				"@microsoft/api-documenter": "^7.21.7",
+				"@microsoft/api-extractor": "^7.34.4",
+				"@types/libsodium-wrappers": "^0.7.11",
+				"@types/lodash-es": "^4.17.6",
+				"@types/tape": "^4.13.2",
+				"@types/ws": "^8.5.5",
+				"@typescript-eslint/eslint-plugin": "^5.62.0",
+				"@typescript-eslint/parser": "^5.62.0",
+				"eslint": "^8.49.0",
+				"eslint-config-prettier": "^8.10.0",
+				"eslint-plugin-prettier": "^4.2.1",
+				"eslint-plugin-tsdoc": "^0.2.17",
+				"js-yaml": "^3.14.1",
+				"prettier": "^2.8.8",
+				"rimraf": "^3.0.2",
+				"tape": "^5.6.6",
+				"tsx": "^4.7.2",
+				"typescript": "^4.9.5"
+			},
+			"engines": {
+				"node": ">=18.0.0 || >=20.0.0"
 			}
 		},
 		"packages/stores/node_modules/typescript": {
@@ -9854,9 +9824,9 @@
 		},
 		"packages/utils": {
 			"name": "@holochain-open-dev/utils",
-			"version": "0.400.0-dev.0",
+			"version": "0.400.0-dev.1",
 			"dependencies": {
-				"@holochain/client": "^0.18.0-dev.0",
+				"@holochain/client": "^0.18.0-dev.10",
 				"@msgpack/msgpack": "^2.8.0",
 				"blakejs": "^1.2.1",
 				"emittery": "^1.0.1",
@@ -10221,25 +10191,6 @@
 			],
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"packages/utils/node_modules/@holochain/client": {
-			"version": "0.18.0-dev.0",
-			"resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.18.0-dev.0.tgz",
-			"integrity": "sha512-xQ4J5rG+t1aJrtzZK8BsJYLsYHgG4zoUvsmoUuiKZcvVRlxPldX+p6rWYWz0JuDxlTE5hjmJmBTPWXd+WVHGNw==",
-			"dependencies": {
-				"@bitgo/blake2b": "^3.2.4",
-				"@holochain/serialization": "^0.1.0-beta-rc.3",
-				"@msgpack/msgpack": "^2.8.0",
-				"emittery": "^1.0.1",
-				"isomorphic-ws": "^5.0.0",
-				"js-base64": "^3.7.5",
-				"libsodium-wrappers": "^0.7.13",
-				"lodash-es": "^4.17.21",
-				"ws": "^8.14.2"
-			},
-			"engines": {
-				"node": ">=18.0.0 || >=20.0.0"
 			}
 		},
 		"packages/utils/node_modules/@rollup/rollup-android-arm-eabi": {

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holochain-open-dev/core-types",
-	"version": "0.400.0-dev.0",
+	"version": "0.400.0-dev.1",
 	"description": "Typescript types for holochain core",
 	"main": "dist/index.js",
 	"module": "dist/index.js",

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -18,7 +18,7 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"@holochain/client": "^0.18.0-dev.0"
+		"@holochain/client": "^0.18.0-dev.10"
 	},
 	"devDependencies": {
 		"@types/libsodium-wrappers": "^0.7.10",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holochain-open-dev/elements",
-	"version": "0.400.0-dev.0",
+	"version": "0.400.0-dev.1",
 	"description": "Common utilities and elements to build Holochain web applications",
 	"author": "guillem.cordoba@gmail.com",
 	"main": "dist/index.js",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -24,7 +24,7 @@
 	},
 	"dependencies": {
 		"@holo-host/identicon": "^0.1.0",
-		"@holochain/client": "^0.18.0-dev.0",
+		"@holochain/client": "^0.18.0-dev.10",
 		"@lit/localize": "^0.12.0",
 		"@mdi/js": "^7.1.96",
 		"@shoelace-style/shoelace": "^2.11.0",

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holochain-open-dev/signals",
-	"version": "0.400.0-dev.0",
+	"version": "0.400.0-dev.1",
 	"description": "Holochain async-signals to build reusable holochain-open-dev modules",
 	"author": "guillem.cordoba@gmail.com",
 	"main": "dist/index.js",
@@ -19,8 +19,8 @@
 		"publish": "npm run build && npm publish --tag dev"
 	},
 	"dependencies": {
-		"@holochain-open-dev/utils": "^0.400.0-dev.0",
-		"@holochain/client": "^0.18.0-dev.0",
+		"@holochain-open-dev/utils": "^0.400.0-dev.1",
+		"@holochain/client": "^0.18.0-dev.10",
 		"@shoelace-style/shoelace": "^2.11.2",
 		"async-signals": "^0.1.7",
 		"lit-signal-watcher": "^0.1.0",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -20,7 +20,7 @@
 	},
 	"dependencies": {
 		"@alenaksu/json-viewer": "^2.0.1",
-		"@holochain-open-dev/utils": "^0.400.0-dev.1",
+		"@holochain-open-dev/utils": "file:../utils",
     "@holochain/client": "^0.18.0-dev.10",
 		"@scoped-elements/cytoscape": "^0.2.0",
 		"@shoelace-style/shoelace": "^2.11.2",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holochain-open-dev/stores",
-	"version": "0.300.0-dev.4",
+	"version": "0.300.0-dev.5",
 	"description": "Re-export of svelte/store, with additional utilities to build reusable holochain-open-dev modules",
 	"author": "guillem.cordoba@gmail.com",
 	"main": "dist/index.js",
@@ -20,8 +20,8 @@
 	},
 	"dependencies": {
 		"@alenaksu/json-viewer": "^2.0.1",
-		"@holochain-open-dev/utils": "^0.300.0-dev.0",
-		"@holochain/client": "^0.17.0-dev.12",
+		"@holochain-open-dev/utils": "^0.400.0-dev.1",
+    "@holochain/client": "^0.18.0-dev.10",
 		"@scoped-elements/cytoscape": "^0.2.0",
 		"@shoelace-style/shoelace": "^2.11.2",
 		"lit": "^3.0.2",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -20,7 +20,7 @@
 	},
 	"dependencies": {
 		"@alenaksu/json-viewer": "^2.0.1",
-		"@holochain-open-dev/utils": "file:../utils",
+		"@holochain-open-dev/utils": "^0.400.0-dev.1",
     "@holochain/client": "^0.18.0-dev.10",
 		"@scoped-elements/cytoscape": "^0.2.0",
 		"@shoelace-style/shoelace": "^2.11.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@holochain-open-dev/utils",
-	"version": "0.400.0-dev.0",
+	"version": "0.400.0-dev.1",
 	"description": "Common utilities to build Holochain web applications",
 	"author": "guillem.cordoba@gmail.com",
 	"main": "dist/index.js",
@@ -23,7 +23,7 @@
 		"publish": "npm run build && npm publish --tag dev"
 	},
 	"dependencies": {
-		"@holochain/client": "^0.18.0-dev.0",
+    "@holochain/client": "^0.18.0-dev.10",
 		"@msgpack/msgpack": "^2.8.0",
 		"blakejs": "^1.2.1",
 		"emittery": "^1.0.1",

--- a/packages/utils/src/cell.ts
+++ b/packages/utils/src/cell.ts
@@ -2,10 +2,11 @@ import {
   AppClient,
   AppWebsocket,
   AppInfo,
-  AppSignal,
   CellId,
   CellType,
   RoleName,
+  Signal,
+  SignalType,
 } from "@holochain/client";
 
 export function roleNameForCellId(
@@ -31,12 +32,14 @@ export function roleNameForCellId(
 export async function isSignalFromCellWithRole(
   client: AppClient,
   roleName: RoleName,
-  signal: AppSignal
+  signal: Signal
 ): Promise<boolean> {
+  const cellId = signal[SignalType.App] ? signal[SignalType.App].cell_id : signal[SignalType.System].cell_id;
+
   if ((client as AppWebsocket).cachedAppInfo) {
     const role = roleNameForCellId(
       (client as AppWebsocket).cachedAppInfo,
-      signal.cell_id
+      cellId
     );
     if (role) {
       return roleName === role;
@@ -47,7 +50,7 @@ export async function isSignalFromCellWithRole(
   // So in this case we _should_ trigger a new fetch of the app info
 
   const appInfo = await client.appInfo();
-  const role = roleNameForCellId(appInfo, signal.cell_id);
+  const role = roleNameForCellId(appInfo, cellId);
 
   return roleName === role;
 }

--- a/packages/utils/src/zome-mock.ts
+++ b/packages/utils/src/zome-mock.ts
@@ -5,7 +5,6 @@ import {
 	AppEvents,
 	AppInfo,
 	AppNetworkInfoRequest,
-	AppSignalCb,
 	CallZomeRequest,
 	CellId,
 	ClonedCell,
@@ -14,6 +13,7 @@ import {
 	EnableCloneCellRequest,
 	EnableCloneCellResponse,
 	NetworkInfoResponse,
+	SignalCb,
 	decodeHashFromBase64,
 } from '@holochain/client';
 import Emittery, { UnsubscribeFunction } from 'emittery';
@@ -34,6 +34,7 @@ export class ZomeMock implements AppClient {
 		),
 		protected latency: number = 500,
 	) {}
+	installedAppId: string;
 
 	get cellId(): CellId {
 		return [
@@ -96,7 +97,7 @@ export class ZomeMock implements AppClient {
 
 	on<Name extends keyof AppEvents>(
 		eventName: Name | readonly Name[],
-		listener: AppSignalCb,
+		listener: SignalCb,
 	): UnsubscribeFunction {
 		return this.emitter.on(eventName, listener);
 	}


### PR DESCRIPTION
I noticed some of the package versions published on npm don't match the package.json -- am I working off the correct branch?

- **BREAKING**: ZomeClient.onSignal now takes a 2nd parameter of SignalType, as holochain now emits both app & system 
signals.
- bump ui package deps to latest for holochain 0.4.0-dev
- added 2 new functions to ZomeClient: `onAppSignal` and `onSystemSignal` which proxy to `onSignal` with specified signal type
- bumped ui package versions 